### PR TITLE
fix: cast text-bound timestamps to TIMESTAMPTZ for PostgreSQL

### DIFF
--- a/src/store/account_store.rs
+++ b/src/store/account_store.rs
@@ -25,8 +25,21 @@ impl AccountStore {
         }
     }
 
+    fn is_pg(&self) -> bool {
+        self.driver == "postgres"
+    }
+
     fn fmt_time(&self, t: DateTime<Utc>) -> String {
         t.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    }
+
+    /// Returns `$N` for SQLite or `$N::TIMESTAMPTZ` for Postgres
+    fn ts(&self, n: u32) -> String {
+        if self.is_pg() {
+            format!("${}::TIMESTAMPTZ", n)
+        } else {
+            format!("${}", n)
+        }
     }
 
     fn parse_time(row: &AnyRow, col: &str) -> DateTime<Utc> {
@@ -130,15 +143,17 @@ impl AccountStore {
         let oauth_refreshed_at = a.oauth_refreshed_at.map(|t| self.fmt_time(t));
 
         let auto_telemetry_int: i32 = if a.auto_telemetry { 1 } else { 0 };
-        let row: AnyRow = sqlx::query(
+        let q = format!(
             r#"INSERT INTO accounts (name, email, status, token, proxy_url,
                 auth_type, access_token, refresh_token, oauth_expires_at, oauth_refreshed_at, auth_error,
                 device_id, canonical_env, canonical_prompt_env, canonical_process,
                 billing_mode, account_uuid, organization_uuid, subscription_type,
                 concurrency, priority, auto_telemetry)
-            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,{},{},{},$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
             RETURNING id, created_at, updated_at"#,
-        )
+            self.ts(9), self.ts(10), "$11"
+        );
+        let row: AnyRow = sqlx::query(&q)
         .bind(&a.name)
         .bind(&a.email)
         .bind(a.status.to_string())
@@ -176,12 +191,12 @@ impl AccountStore {
         let auto_telemetry_int: i32 = if a.auto_telemetry { 1 } else { 0 };
         let q = format!(
             r#"UPDATE accounts SET name=$1, email=$2, status=$3, token=$4,
-                auth_type=$5, access_token=$6, refresh_token=$7, oauth_expires_at=$8, oauth_refreshed_at=$9,
+                auth_type=$5, access_token=$6, refresh_token=$7, oauth_expires_at={}, oauth_refreshed_at={},
                 auth_error=$10, proxy_url=$11, billing_mode=$12,
                 account_uuid=$13, organization_uuid=$14, subscription_type=$15,
                 concurrency=$16, priority=$17, auto_telemetry=$18, updated_at={}
             WHERE id=$19"#,
-            self.now_expr()
+            self.ts(8), self.ts(9), self.now_expr()
         );
         sqlx::query(&q)
             .bind(&a.name)
@@ -216,10 +231,10 @@ impl AccountStore {
         expires_at: DateTime<Utc>,
     ) -> Result<(), AppError> {
         let q = format!(
-            r#"UPDATE accounts SET access_token=$1, refresh_token=$2, oauth_expires_at=$3,
-                oauth_refreshed_at=$4, auth_error='', updated_at={}
+            r#"UPDATE accounts SET access_token=$1, refresh_token=$2, oauth_expires_at={},
+                oauth_refreshed_at={}, auth_error='', updated_at={}
             WHERE id=$5"#,
-            self.now_expr()
+            self.ts(3), self.ts(4), self.now_expr()
         );
         sqlx::query(&q)
             .bind(access_token)
@@ -268,8 +283,8 @@ impl AccountStore {
         reset_at: DateTime<Utc>,
     ) -> Result<(), AppError> {
         let q = format!(
-            "UPDATE accounts SET rate_limited_at=$1, rate_limit_reset_at=$2, updated_at={} WHERE id=$3",
-            self.now_expr()
+            "UPDATE accounts SET rate_limited_at={}, rate_limit_reset_at={}, updated_at={} WHERE id=$3",
+            self.ts(1), self.ts(2), self.now_expr()
         );
         sqlx::query(&q)
             .bind(self.fmt_time(Utc::now()))
@@ -289,9 +304,9 @@ impl AccountStore {
     ) -> Result<(), AppError> {
         let q = format!(
             r#"UPDATE accounts SET status=$1, disable_reason=$2,
-                rate_limited_at=$3, rate_limit_reset_at=$4, updated_at={}
+                rate_limited_at={}, rate_limit_reset_at={}, updated_at={}
             WHERE id=$5"#,
-            self.now_expr()
+            self.ts(3), self.ts(4), self.now_expr()
         );
         let limited_str = rate_limit_reset_at.map(|_| self.fmt_time(Utc::now()));
         let reset_str = rate_limit_reset_at.map(|t| self.fmt_time(t));
@@ -383,8 +398,8 @@ impl AccountStore {
 
     pub async fn update_usage(&self, id: i64, usage_data: &str) -> Result<(), AppError> {
         let q = format!(
-            "UPDATE accounts SET usage_data=$1, usage_fetched_at=$2, updated_at={} WHERE id=$3",
-            self.now_expr()
+            "UPDATE accounts SET usage_data=$1, usage_fetched_at={}, updated_at={} WHERE id=$3",
+            self.ts(2), self.now_expr()
         );
         sqlx::query(&q)
             .bind(usage_data)

--- a/src/store/account_store.rs
+++ b/src/store/account_store.rs
@@ -444,3 +444,64 @@ const ACCOUNT_COLS: &str = r#"id, name, email, status, token, auth_type, access_
     concurrency, priority, rate_limited_at, rate_limit_reset_at,
     disable_reason, auto_telemetry, telemetry_count,
     usage_data, usage_fetched_at, created_at, updated_at"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn make_store(driver: &str) -> AccountStore {
+        sqlx::any::install_default_drivers();
+        let tmp = std::env::temp_dir().join(format!("ccgw_unit_{}.db", rand::random::<u64>()));
+        let dsn = format!("sqlite:{}?mode=rwc", tmp.display());
+        let pool = AnyPool::connect(&dsn).await.expect("pool");
+        AccountStore {
+            pool,
+            driver: driver.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ts_sqlite_plain_placeholder() {
+        let store = make_store("sqlite").await;
+        assert_eq!(store.ts(1), "$1");
+        assert_eq!(store.ts(5), "$5");
+        assert_eq!(store.ts(10), "$10");
+    }
+
+    #[tokio::test]
+    async fn test_ts_postgres_casts_to_timestamptz() {
+        let store = make_store("postgres").await;
+        assert_eq!(store.ts(1), "$1::TIMESTAMPTZ");
+        assert_eq!(store.ts(5), "$5::TIMESTAMPTZ");
+        assert_eq!(store.ts(10), "$10::TIMESTAMPTZ");
+    }
+
+    #[tokio::test]
+    async fn test_is_pg() {
+        assert!(make_store("postgres").await.is_pg());
+        assert!(!make_store("sqlite").await.is_pg());
+    }
+
+    #[tokio::test]
+    async fn test_now_expr_sqlite() {
+        let store = make_store("sqlite").await;
+        assert_eq!(store.now_expr(), "strftime('%Y-%m-%dT%H:%M:%SZ','now')");
+    }
+
+    #[tokio::test]
+    async fn test_now_expr_postgres() {
+        let store = make_store("postgres").await;
+        assert_eq!(store.now_expr(), "NOW()");
+    }
+
+    #[tokio::test]
+    async fn test_fmt_time_iso8601() {
+        let store = make_store("sqlite").await;
+        let t = chrono::NaiveDate::from_ymd_opt(2026, 4, 9)
+            .unwrap()
+            .and_hms_opt(12, 30, 45)
+            .unwrap()
+            .and_utc();
+        assert_eq!(store.fmt_time(t), "2026-04-09T12:30:45Z");
+    }
+}

--- a/tests/account_scheduler_test.rs
+++ b/tests/account_scheduler_test.rs
@@ -55,6 +55,8 @@ async fn create_test_account(svc: &AccountService, email: &str) -> Account {
         rate_limited_at: None,
         rate_limit_reset_at: None,
         disable_reason: String::new(),
+        auto_telemetry: false,
+        telemetry_count: 0,
         usage_data: serde_json::json!({}),
         usage_fetched_at: None,
         created_at: Utc::now(),

--- a/tests/account_store_timestamp_test.rs
+++ b/tests/account_store_timestamp_test.rs
@@ -1,0 +1,232 @@
+use chrono::{Duration, Utc};
+use sqlx::AnyPool;
+use std::sync::Arc;
+
+use claude_code_gateway::model::account::{Account, AccountAuthType, AccountStatus, BillingMode};
+use claude_code_gateway::store::account_store::AccountStore;
+
+async fn setup() -> Arc<AccountStore> {
+    sqlx::any::install_default_drivers();
+    let tmp = std::env::temp_dir().join(format!("ccgw_ts_test_{}.db", rand::random::<u64>()));
+    let dsn = format!("sqlite:{}?mode=rwc", tmp.display());
+    let pool = AnyPool::connect(&dsn)
+        .await
+        .expect("failed to create sqlite pool");
+    claude_code_gateway::store::db::migrate(&pool, "sqlite")
+        .await
+        .expect("failed to run migrations");
+    Arc::new(AccountStore::new(pool, "sqlite".into()))
+}
+
+fn new_account(email: &str) -> Account {
+    Account {
+        id: 0,
+        name: "ts-test".into(),
+        email: email.into(),
+        status: AccountStatus::Active,
+        auth_type: AccountAuthType::Oauth,
+        setup_token: "sk-ant-oat01-test-placeholder".into(),
+        access_token: "access-tok".into(),
+        refresh_token: "refresh-tok".into(),
+        expires_at: Some(Utc::now() + Duration::hours(1)),
+        oauth_refreshed_at: Some(Utc::now()),
+        auth_error: String::new(),
+        proxy_url: String::new(),
+        device_id: String::new(),
+        canonical_env: serde_json::json!({}),
+        canonical_prompt: serde_json::json!({}),
+        canonical_process: serde_json::json!({}),
+        billing_mode: BillingMode::Strip,
+        account_uuid: None,
+        organization_uuid: None,
+        subscription_type: None,
+        concurrency: 3,
+        priority: 50,
+        rate_limited_at: None,
+        rate_limit_reset_at: None,
+        disable_reason: String::new(),
+        auto_telemetry: false,
+        telemetry_count: 0,
+        usage_data: serde_json::json!({}),
+        usage_fetched_at: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+// ─── CREATE: oauth_expires_at and oauth_refreshed_at bound as timestamps ───
+
+#[tokio::test]
+async fn test_create_account_with_oauth_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("create-ts@example.com");
+    store.create(&mut a).await.expect("create failed");
+    assert!(a.id > 0);
+
+    let fetched = store.get_by_id(a.id).await.expect("get_by_id failed");
+    assert!(fetched.expires_at.is_some());
+    assert!(fetched.oauth_refreshed_at.is_some());
+}
+
+#[tokio::test]
+async fn test_create_account_with_null_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("create-null-ts@example.com");
+    a.expires_at = None;
+    a.oauth_refreshed_at = None;
+    store.create(&mut a).await.expect("create failed");
+
+    let fetched = store.get_by_id(a.id).await.expect("get_by_id failed");
+    assert!(fetched.expires_at.is_none());
+    assert!(fetched.oauth_refreshed_at.is_none());
+}
+
+// ─── UPDATE: oauth_expires_at and oauth_refreshed_at ───
+
+#[tokio::test]
+async fn test_update_account_with_oauth_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("update-ts@example.com");
+    store.create(&mut a).await.unwrap();
+
+    let new_expiry = Utc::now() + Duration::hours(2);
+    let new_refreshed = Utc::now();
+    a.expires_at = Some(new_expiry);
+    a.oauth_refreshed_at = Some(new_refreshed);
+    store.update(&a).await.expect("update failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert!(fetched.expires_at.is_some());
+    assert!(fetched.oauth_refreshed_at.is_some());
+}
+
+// ─── UPDATE_OAUTH_TOKENS: oauth_expires_at and oauth_refreshed_at ───
+
+#[tokio::test]
+async fn test_update_oauth_tokens_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("oauth-tok@example.com");
+    store.create(&mut a).await.unwrap();
+
+    let new_expiry = Utc::now() + Duration::hours(3);
+    store
+        .update_oauth_tokens(a.id, "new-access", "new-refresh", new_expiry)
+        .await
+        .expect("update_oauth_tokens failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert_eq!(fetched.access_token, "new-access");
+    assert_eq!(fetched.refresh_token, "new-refresh");
+    assert!(fetched.expires_at.is_some());
+    assert!(fetched.oauth_refreshed_at.is_some());
+    assert!(fetched.auth_error.is_empty());
+}
+
+// ─── SET_RATE_LIMIT: rate_limited_at and rate_limit_reset_at ───
+
+#[tokio::test]
+async fn test_set_rate_limit_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("rate-limit@example.com");
+    store.create(&mut a).await.unwrap();
+
+    let reset_at = Utc::now() + Duration::hours(5);
+    store
+        .set_rate_limit(a.id, reset_at)
+        .await
+        .expect("set_rate_limit failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert!(fetched.rate_limited_at.is_some());
+    assert!(fetched.rate_limit_reset_at.is_some());
+}
+
+// ─── DISABLE_ACCOUNT: rate_limited_at and rate_limit_reset_at ───
+
+#[tokio::test]
+async fn test_disable_account_with_rate_limit_timestamps() {
+    let store = setup().await;
+    let mut a = new_account("disable-ts@example.com");
+    store.create(&mut a).await.unwrap();
+
+    let reset_at = Utc::now() + Duration::hours(1);
+    store
+        .disable_account(a.id, AccountStatus::Active, "rate limited", Some(reset_at))
+        .await
+        .expect("disable_account failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert!(fetched.rate_limited_at.is_some());
+    assert!(fetched.rate_limit_reset_at.is_some());
+    assert_eq!(fetched.disable_reason, "rate limited");
+}
+
+#[tokio::test]
+async fn test_disable_account_without_rate_limit() {
+    let store = setup().await;
+    let mut a = new_account("disable-no-rl@example.com");
+    store.create(&mut a).await.unwrap();
+
+    store
+        .disable_account(a.id, AccountStatus::Disabled, "manual", None)
+        .await
+        .expect("disable_account failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert!(fetched.rate_limited_at.is_none());
+    assert!(fetched.rate_limit_reset_at.is_none());
+    assert_eq!(fetched.status, AccountStatus::Disabled);
+}
+
+// ─── UPDATE_USAGE: usage_fetched_at ───
+
+#[tokio::test]
+async fn test_update_usage_timestamp() {
+    let store = setup().await;
+    let mut a = new_account("usage-ts@example.com");
+    store.create(&mut a).await.unwrap();
+
+    store
+        .update_usage(a.id, r#"{"tokens": 1000}"#)
+        .await
+        .expect("update_usage failed");
+
+    let fetched = store.get_by_id(a.id).await.unwrap();
+    assert!(fetched.usage_fetched_at.is_some());
+}
+
+// ─── LIST_SCHEDULABLE: rate_limit_reset_at comparison ───
+
+#[tokio::test]
+async fn test_list_schedulable_excludes_rate_limited() {
+    let store = setup().await;
+    let mut a = new_account("sched-limited@example.com");
+    store.create(&mut a).await.unwrap();
+
+    // Set a future rate limit
+    let reset_at = Utc::now() + Duration::hours(1);
+    store.set_rate_limit(a.id, reset_at).await.unwrap();
+
+    let schedulable = store.list_schedulable().await.unwrap();
+    assert!(
+        schedulable.iter().all(|acc| acc.id != a.id),
+        "rate-limited account should not be schedulable"
+    );
+}
+
+#[tokio::test]
+async fn test_list_schedulable_includes_expired_rate_limit() {
+    let store = setup().await;
+    let mut a = new_account("sched-expired@example.com");
+    store.create(&mut a).await.unwrap();
+
+    // Set an already-expired rate limit
+    let reset_at = Utc::now() - Duration::seconds(10);
+    store.set_rate_limit(a.id, reset_at).await.unwrap();
+
+    let schedulable = store.list_schedulable().await.unwrap();
+    assert!(
+        schedulable.iter().any(|acc| acc.id == a.id),
+        "account with expired rate limit should be schedulable"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `ts(n)` helper that emits `$N::TIMESTAMPTZ` for Postgres, plain `$N` for SQLite
- Apply the cast to all 6 methods that bind timestamps: `create`, `update`, `update_oauth_tokens`, `set_rate_limit`, `disable_account`, `update_usage`

Closes #4

## Test plan
- [ ] Run with `DATABASE_DRIVER=postgres` and create/update an OAuth account — no more type mismatch error
- [ ] Run with `DATABASE_DRIVER=sqlite` — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)