### PR TITLE
fix: correct Redis URL construction (double /db)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,12 +41,6 @@ pub struct AdminConfig {
     pub password: String,
 }
 
-impl RedisConfig {
-    pub fn addr(&self) -> String {
-        format!("redis://{}:{}/{}", self.host, self.port, self.db)
-    }
-}
-
 impl DatabaseConfig {
     pub fn driver(&self) -> String {
         self.driver.clone().unwrap_or_else(|| "sqlite".into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,12 @@ async fn main() {
     // 缓存：优先 Redis，回退内存
     let cache: Arc<dyn store::cache::CacheStore> = match &cfg.redis {
         Some(redis_cfg) => {
-            match store::redis::RedisStore::new(&redis_cfg.addr(), &redis_cfg.password, redis_cfg.db)
+            match store::redis::RedisStore::new(
+                &redis_cfg.host,
+                redis_cfg.port,
+                &redis_cfg.password,
+                redis_cfg.db,
+            )
                 .await
             {
                 Ok(r) => {

--- a/src/store/redis.rs
+++ b/src/store/redis.rs
@@ -8,15 +8,21 @@ pub struct RedisStore {
     client: redis::aio::ConnectionManager,
 }
 
+/// Build a Redis connection URL from discrete components.
+///
+/// Kept as a pure function so it can be unit-tested without a live Redis server.
+/// The database number is encoded exactly once as the URL path.
+pub fn build_redis_url(host: &str, port: u16, password: &str, db: i64) -> String {
+    if password.is_empty() {
+        format!("redis://{}:{}/{}", host, port, db)
+    } else {
+        format!("redis://:{}@{}:{}/{}", password, host, port, db)
+    }
+}
+
 impl RedisStore {
-    pub async fn new(addr: &str, password: &str, db: i64) -> Result<Self, AppError> {
-        let url = if password.is_empty() {
-            format!("{}/{}", addr, db)
-        } else {
-            // Rebuild URL with password
-            let base = addr.trim_start_matches("redis://");
-            format!("redis://:{}@{}/{}", password, base, db)
-        };
+    pub async fn new(host: &str, port: u16, password: &str, db: i64) -> Result<Self, AppError> {
+        let url = build_redis_url(host, port, password, db);
         let client = redis::Client::open(url)
             .map_err(|e| AppError::Internal(format!("redis open: {}", e)))?;
         let mgr = redis::aio::ConnectionManager::new(client)

--- a/tests/redis_url_test.rs
+++ b/tests/redis_url_test.rs
@@ -1,0 +1,68 @@
+//! Regression tests for Redis connection URL construction.
+//!
+//! Previously `RedisStore::new` concatenated `addr` (which already contained
+//! `/{db}`) with `/{db}` again, producing URLs like `redis://host:6379/0/0`
+//! that the `redis` crate rejects with `InvalidClientConfig`.
+//!
+//! See issue #6 / `fix: correct Redis URL construction (double /db)`.
+
+use claude_code_gateway::store::redis::build_redis_url;
+
+#[test]
+fn build_url_without_password() {
+    let url = build_redis_url("127.0.0.1", 6379, "", 0);
+    assert_eq!(url, "redis://127.0.0.1:6379/0");
+}
+
+#[test]
+fn build_url_with_password() {
+    let url = build_redis_url("127.0.0.1", 6379, "secret", 0);
+    assert_eq!(url, "redis://:secret@127.0.0.1:6379/0");
+}
+
+#[test]
+fn build_url_with_non_zero_db() {
+    let url = build_redis_url("redis.internal", 6380, "", 3);
+    assert_eq!(url, "redis://redis.internal:6380/3");
+}
+
+#[test]
+fn build_url_with_password_and_non_zero_db() {
+    let url = build_redis_url("redis.internal", 6380, "p@ss", 7);
+    assert_eq!(url, "redis://:p@ss@redis.internal:6380/7");
+}
+
+/// Critical regression: the db path segment must appear exactly once.
+/// The old buggy code produced `.../0/0` which `redis::Client::open` rejects
+/// as `Invalid database number- InvalidClientConfig`.
+#[test]
+fn url_contains_db_exactly_once() {
+    let cases = [
+        build_redis_url("host", 6379, "", 0),
+        build_redis_url("host", 6379, "pw", 0),
+        build_redis_url("host", 6379, "", 5),
+        build_redis_url("host", 6379, "pw", 5),
+    ];
+    for url in cases {
+        // Strip scheme, then count path slashes. There must be exactly one:
+        // the slash preceding the db segment.
+        let after_scheme = url.strip_prefix("redis://").expect("redis:// scheme");
+        let slashes: usize = after_scheme.chars().filter(|c| *c == '/').count();
+        assert_eq!(
+            slashes, 1,
+            "expected exactly one '/' after the authority in {url}"
+        );
+    }
+}
+
+/// The constructed URL must be accepted by `redis::Client::open`. This is the
+/// narrowest possible live-parser check — it does not connect to a server,
+/// it only exercises URL parsing, which is what failed before the fix.
+#[test]
+fn parsed_by_redis_client() {
+    let url = build_redis_url("127.0.0.1", 6379, "", 0);
+    redis::Client::open(url).expect("redis client should accept the URL");
+
+    let url = build_redis_url("127.0.0.1", 6379, "secret", 2);
+    redis::Client::open(url).expect("redis client should accept URL with password and db");
+}


### PR DESCRIPTION
## Summary

- `RedisConfig::addr()` already encoded the db into the URL path, and `RedisStore::new` was appending `/{db}` again — producing `redis://host:port/0/0`, which the `redis` crate rejects as `Invalid database number- InvalidClientConfig`. Redis was silently unreachable on every startup and the gateway always fell back to the in-memory cache.
- Extracted a pure `build_redis_url(host, port, password, db)` helper, changed `RedisStore::new` to take the components directly, and removed the now-unused `RedisConfig::addr()`.
- Added `tests/redis_url_test.rs` with 6 unit tests, including a regression assertion that the URL contains exactly one path slash and parses via `redis::Client::open` (the call site that failed before).

Closes #6

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test --test redis_url_test` — 6 passed
- [ ] Manual: start the gateway with `REDIS_HOST=...` and confirm the log shows `using redis cache` instead of `redis unavailable (...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)