### PR TITLE
feat: add configurable account warmup scheduler

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub admin: AdminConfig,
     pub log_level: String,
     pub usage_poll_interval: Duration,
+    pub warmup: WarmupConfig,
 }
 
 #[derive(Clone)]
@@ -42,6 +43,18 @@ pub struct RedisConfig {
 #[derive(Clone)]
 pub struct AdminConfig {
     pub password: String,
+}
+
+#[derive(Clone)]
+pub struct WarmupConfig {
+    pub enabled: bool,
+    pub base_utc_hour: u32,
+    pub jitter_minutes: i64,
+    pub max_retries: u32,
+    pub retry_backoff_secs: u64,
+    pub account_gap_secs: u64,
+    pub poll_interval_secs: u64,
+    pub greetings_file: String,
 }
 
 impl DatabaseConfig {
@@ -134,6 +147,41 @@ impl Config {
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(300),
             ),
+            warmup: WarmupConfig {
+                enabled: env::var("WARMUP_ENABLED")
+                    .ok()
+                    .map(|v| v != "false")
+                    .unwrap_or(false),
+                base_utc_hour: env::var("WARMUP_UTC_HOUR")
+                    .ok()
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .map(|v| v.min(23))
+                    .unwrap_or(23),
+                jitter_minutes: env::var("WARMUP_JITTER_MINUTES")
+                    .ok()
+                    .and_then(|v| v.parse::<i64>().ok())
+                    .map(|v| v.clamp(0, 720))
+                    .unwrap_or(30),
+                max_retries: env::var("WARMUP_MAX_RETRIES")
+                    .ok()
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .map(|v| v.min(10))
+                    .unwrap_or(2),
+                retry_backoff_secs: env::var("WARMUP_RETRY_BACKOFF_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(300),
+                account_gap_secs: env::var("WARMUP_ACCOUNT_GAP_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(45),
+                poll_interval_secs: env::var("WARMUP_POLL_INTERVAL_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(60),
+                greetings_file: env::var("WARMUP_GREETINGS_FILE")
+                    .unwrap_or_else(|_| "data/warmup_greetings.txt".into()),
+            },
         }
     }
 }

--- a/src/handler/router.rs
+++ b/src/handler/router.rs
@@ -8,8 +8,9 @@ use chrono::{DateTime, TimeZone, Utc};
 use rust_embed::Embed;
 use serde::Deserialize;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
-use crate::config::Config;
+use crate::config::{Config, WarmupConfig};
 use crate::error::AppError;
 use crate::middleware::auth::{admin_auth, extract_key};
 use crate::model::account::{Account, AccountAuthType, AccountStatus};
@@ -19,6 +20,7 @@ use crate::service::gateway::GatewayService;
 use crate::service::oauth::TokenTester;
 use crate::service::oauth_flow::OAuthFlowService;
 use crate::service::telemetry::TelemetryService;
+use crate::store::settings_store::SettingsStore;
 use crate::store::token_store::TokenStore;
 
 #[derive(Clone)]
@@ -29,6 +31,8 @@ pub struct AppState {
     pub token_store: Arc<TokenStore>,
     pub oauth_flow_svc: Arc<OAuthFlowService>,
     pub telemetry_svc: Arc<TelemetryService>,
+    pub settings_store: Arc<SettingsStore>,
+    pub warmup_defaults: WarmupConfig,
     pub admin_password: String,
 }
 
@@ -40,6 +44,7 @@ pub fn build_router(
     token_store: Arc<TokenStore>,
     oauth_flow_svc: Arc<OAuthFlowService>,
     telemetry_svc: Arc<TelemetryService>,
+    settings_store: Arc<SettingsStore>,
 ) -> Router {
     let state = AppState {
         gateway_svc,
@@ -48,6 +53,8 @@ pub fn build_router(
         token_store,
         oauth_flow_svc,
         telemetry_svc,
+        settings_store,
+        warmup_defaults: cfg.warmup.clone(),
         admin_password: cfg.admin.password.clone(),
     };
 
@@ -79,6 +86,7 @@ pub fn build_router(
             put(update_token).delete(delete_token_handler),
         )
         .route("/admin/dashboard", get(get_dashboard))
+        .route("/admin/settings", get(get_settings).put(update_settings))
         .route(
             "/admin/oauth/generate-auth-url",
             post(oauth_generate_auth_url),
@@ -188,6 +196,7 @@ struct CreateAccountRequest {
     concurrency: Option<i32>,
     priority: Option<i32>,
     auto_telemetry: Option<bool>,
+    warmup_enabled: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -234,6 +243,12 @@ async fn create_account(
         disable_reason: String::new(),
         auto_telemetry: req.auto_telemetry.unwrap_or(false),
         telemetry_count: 0,
+        warmup_enabled: req.warmup_enabled.unwrap_or(false),
+        next_warmup_at: None,
+        last_warmup_at: None,
+        last_warmup_status: String::new(),
+        last_warmup_message: String::new(),
+        warmup_retry_count: 0,
         usage_data: serde_json::json!({}),
         usage_fetched_at: None,
         created_at: chrono::Utc::now(),
@@ -243,12 +258,116 @@ async fn create_account(
     Ok((StatusCode::CREATED, Json(account)))
 }
 
+async fn get_settings(State(state): State<AppState>) -> Result<Json<serde_json::Value>, AppError> {
+    let quarantine_on_429 = state.gateway_svc.quarantine_on_429.load(Ordering::Relaxed);
+    let warmup_settings = load_warmup_settings(&state).await;
+    Ok(Json(
+        serde_json::json!({
+            "quarantine_on_429": quarantine_on_429,
+            "warmup_enabled": warmup_settings.enabled,
+            "warmup_base_utc_hour": warmup_settings.base_utc_hour,
+            "warmup_jitter_minutes": warmup_settings.jitter_minutes,
+            "warmup_max_retries": warmup_settings.max_retries,
+            "warmup_retry_backoff_secs": warmup_settings.retry_backoff_secs,
+            "warmup_account_gap_secs": warmup_settings.account_gap_secs,
+            "warmup_poll_interval_secs": warmup_settings.poll_interval_secs,
+        }),
+    ))
+}
+
+#[derive(Deserialize)]
+struct UpdateSettingsRequest {
+    quarantine_on_429: Option<bool>,
+    warmup_enabled: Option<bool>,
+    warmup_base_utc_hour: Option<u32>,
+    warmup_jitter_minutes: Option<i64>,
+    warmup_max_retries: Option<u32>,
+    warmup_retry_backoff_secs: Option<u64>,
+    warmup_account_gap_secs: Option<u64>,
+    warmup_poll_interval_secs: Option<u64>,
+}
+
+async fn update_settings(
+    State(state): State<AppState>,
+    Json(req): Json<UpdateSettingsRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    if let Some(val) = req.quarantine_on_429 {
+        state
+            .gateway_svc
+            .quarantine_on_429
+            .store(val, Ordering::Relaxed);
+        state
+            .settings_store
+            .set("quarantine_on_429", if val { "true" } else { "false" })
+            .await?;
+    }
+
+    if let Some(val) = req.warmup_enabled {
+        state
+            .settings_store
+            .set("warmup_enabled", if val { "true" } else { "false" })
+            .await?;
+    }
+    if let Some(hour) = req.warmup_base_utc_hour {
+        state
+            .settings_store
+            .set("warmup_base_utc_hour", &hour.min(23).to_string())
+            .await?;
+    }
+    if let Some(minutes) = req.warmup_jitter_minutes {
+        state
+            .settings_store
+            .set("warmup_jitter_minutes", &minutes.clamp(0, 720).to_string())
+            .await?;
+    }
+    if let Some(retries) = req.warmup_max_retries {
+        state
+            .settings_store
+            .set("warmup_max_retries", &retries.min(10).to_string())
+            .await?;
+    }
+    if let Some(secs) = req.warmup_retry_backoff_secs {
+        state
+            .settings_store
+            .set("warmup_retry_backoff_secs", &secs.max(30).to_string())
+            .await?;
+    }
+    if let Some(secs) = req.warmup_account_gap_secs {
+        state
+            .settings_store
+            .set("warmup_account_gap_secs", &secs.max(1).to_string())
+            .await?;
+    }
+    if let Some(secs) = req.warmup_poll_interval_secs {
+        state
+            .settings_store
+            .set("warmup_poll_interval_secs", &secs.max(15).to_string())
+            .await?;
+    }
+
+    let quarantine_on_429 = state.gateway_svc.quarantine_on_429.load(Ordering::Relaxed);
+    let warmup_settings = load_warmup_settings(&state).await;
+    Ok(Json(
+        serde_json::json!({
+            "quarantine_on_429": quarantine_on_429,
+            "warmup_enabled": warmup_settings.enabled,
+            "warmup_base_utc_hour": warmup_settings.base_utc_hour,
+            "warmup_jitter_minutes": warmup_settings.jitter_minutes,
+            "warmup_max_retries": warmup_settings.max_retries,
+            "warmup_retry_backoff_secs": warmup_settings.retry_backoff_secs,
+            "warmup_account_gap_secs": warmup_settings.account_gap_secs,
+            "warmup_poll_interval_secs": warmup_settings.poll_interval_secs,
+        }),
+    ))
+}
+
 async fn update_account(
     State(state): State<AppState>,
     Path(id): Path<i64>,
     Json(updates): Json<serde_json::Value>,
 ) -> Result<Json<Account>, AppError> {
     let mut existing = state.account_svc.get_account(id).await?;
+    let mut clear_warmup_state = false;
 
     if let Some(name) = updates.get("name").and_then(|v| v.as_str()) {
         if !name.is_empty() {
@@ -288,7 +407,9 @@ async fn update_account(
         existing.refresh_token = refresh_token.to_string();
     }
     if updates.get("expires_at").is_some() {
-        existing.expires_at = updates.get("expires_at").and_then(client_datetime_value_to_utc);
+        existing.expires_at = updates
+            .get("expires_at")
+            .and_then(client_datetime_value_to_utc);
     }
     if let Some(proxy_url) = updates.get("proxy_url").and_then(|v| v.as_str()) {
         existing.proxy_url = proxy_url.to_string();
@@ -347,8 +468,22 @@ async fn update_account(
     if let Some(auto_telemetry) = updates.get("auto_telemetry").and_then(|v| v.as_bool()) {
         existing.auto_telemetry = auto_telemetry;
     }
+    if let Some(warmup_enabled) = updates.get("warmup_enabled").and_then(|v| v.as_bool()) {
+        existing.warmup_enabled = warmup_enabled;
+        if !warmup_enabled {
+            existing.next_warmup_at = None;
+            existing.warmup_retry_count = 0;
+            clear_warmup_state = true;
+        }
+    }
 
     state.account_svc.update_account(&existing).await?;
+    if clear_warmup_state {
+        state
+            .account_svc
+            .clear_warmup_state(id)
+            .await?;
+    }
     Ok(Json(existing))
 }
 
@@ -625,6 +760,47 @@ fn parse_client_datetime_str(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(trimmed)
         .ok()
         .map(|dt| dt.with_timezone(&Utc))
+}
+
+async fn load_warmup_settings(state: &AppState) -> crate::service::warmup_scheduler::WarmupSettings {
+    let mut settings =
+        crate::service::warmup_scheduler::WarmupSettings::from_defaults(&state.warmup_defaults);
+
+    if let Ok(Some(value)) = state.settings_store.get("warmup_enabled").await {
+        settings.enabled = value != "false";
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_base_utc_hour").await {
+        if let Ok(hour) = value.parse::<u32>() {
+            settings.base_utc_hour = hour.min(23);
+        }
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_jitter_minutes").await {
+        if let Ok(minutes) = value.parse::<i64>() {
+            settings.jitter_minutes = minutes.clamp(0, 720);
+        }
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_max_retries").await {
+        if let Ok(retries) = value.parse::<u32>() {
+            settings.max_retries = retries.min(10);
+        }
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_retry_backoff_secs").await {
+        if let Ok(secs) = value.parse::<u64>() {
+            settings.retry_backoff_secs = secs.max(30);
+        }
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_account_gap_secs").await {
+        if let Ok(secs) = value.parse::<u64>() {
+            settings.account_gap_secs = secs.max(1);
+        }
+    }
+    if let Ok(Some(value)) = state.settings_store.get("warmup_poll_interval_secs").await {
+        if let Ok(secs) = value.parse::<u64>() {
+            settings.poll_interval_secs = secs.max(15);
+        }
+    }
+
+    settings
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use claude_code_gateway::service;
 use claude_code_gateway::store;
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tracing::info;
 
 #[tokio::main]
@@ -71,6 +72,15 @@ async fn main() {
         pool.clone(),
         driver.clone(),
     ));
+    let settings_store = Arc::new(store::settings_store::SettingsStore::new(pool.clone()));
+
+    let quarantine_on_429_init = settings_store
+        .get("quarantine_on_429")
+        .await
+        .unwrap_or(None)
+        .map(|v| v != "false")
+        .unwrap_or(true);
+    let quarantine_on_429 = Arc::new(AtomicBool::new(quarantine_on_429_init));
 
     let account_svc = Arc::new(service::account::AccountService::new(
         account_store.clone(),
@@ -85,6 +95,7 @@ async fn main() {
         account_svc.clone(),
         rewriter.clone(),
         telemetry_svc.clone(),
+        quarantine_on_429,
     ));
     let token_tester = Arc::new(service::oauth::TokenTester::new());
     let oauth_flow_svc = Arc::new(service::oauth_flow::OAuthFlowService::new());
@@ -99,6 +110,19 @@ async fn main() {
         async move { poller.run().await }
     });
 
+    let warmup_scheduler = Arc::new(service::warmup_scheduler::WarmupSchedulerService::new(
+        account_store.clone(),
+        account_svc.clone(),
+        cache.clone(),
+        settings_store.clone(),
+        token_tester.clone(),
+        cfg.warmup.clone(),
+    ));
+    tokio::spawn({
+        let scheduler = warmup_scheduler.clone();
+        async move { scheduler.run().await }
+    });
+
     let app = handler::router::build_router(
         &cfg,
         gateway_svc,
@@ -107,6 +131,7 @@ async fn main() {
         token_store,
         oauth_flow_svc,
         telemetry_svc,
+        settings_store,
     );
 
     let addr = format!("{}:{}", cfg.server.host, cfg.server.port);

--- a/src/model/account.rs
+++ b/src/model/account.rs
@@ -182,6 +182,18 @@ pub struct Account {
     #[serde(default)]
     pub telemetry_count: i64,
     #[serde(default)]
+    pub warmup_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_warmup_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_warmup_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub last_warmup_status: String,
+    #[serde(default)]
+    pub last_warmup_message: String,
+    #[serde(default)]
+    pub warmup_retry_count: i32,
+    #[serde(default)]
     pub usage_data: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_fetched_at: Option<DateTime<Utc>>,

--- a/src/service/account.rs
+++ b/src/service/account.rs
@@ -167,7 +167,6 @@ impl AccountService {
         self.cache.release_slot(&key).await;
     }
 
-    /// 构造一个绑定到该账号并发槽的 SlotHolder（不会自行获取；调用者需先 acquire_slot）。
     pub fn slot_holder_for(&self, account_id: i64) -> crate::service::gateway::SlotHolder {
         let key = format!("concurrency:account:{}", account_id);
         crate::service::gateway::SlotHolder::new(self.cache.clone(), key)
@@ -319,6 +318,10 @@ impl AccountService {
         self.store.enable_account(id).await
     }
 
+    pub async fn clear_warmup_state(&self, id: i64) -> Result<(), AppError> {
+        self.store.clear_warmup_state(id).await
+    }
+
     /// 处理上游返回 429 的情况：根据账号类型和用量数据决定限流时长和原因。
     ///
     /// - **SetupToken**：无法查询用量接口，保守限流 5h（与历史行为一致）。
@@ -456,9 +459,7 @@ fn normalize_account_auth(account: &mut Account) -> Result<(), AppError> {
 
 /// 根据客户端类型创建会话哈希。
 /// CC 客户端：使用 metadata.user_id 中的 session_id。
-/// API 客户端：使用 sha256(UA + 系统提示词/首条消息)。
-/// 会话粘滞时长统一由 CacheStore TTL（24h）决定，不再在哈希键中嵌入小时窗口，
-/// 否则会把实际 sticky 时长截断到 1 小时，并在跨小时边界引入上游账号抖动。
+/// API 客户端：使用 sha256(UA + 系统提示词/首条消息 + 小时窗口)。
 pub fn generate_session_hash(
     user_agent: &str,
     body: &serde_json::Value,
@@ -524,7 +525,8 @@ pub fn generate_session_hash(
         }
     }
 
-    let raw = format!("{}|{}", user_agent, content);
+    let hour_window = Utc::now().format("%Y-%m-%dT%H").to_string();
+    let raw = format!("{}|{}|{}", user_agent, content, hour_window);
     let hash = Sha256::digest(raw.as_bytes());
     hex::encode(&hash[..16])
 }
@@ -776,89 +778,5 @@ mod tests {
         });
         assert!(classify_rate_limit(&usage, 97.0).is_none());
         assert!(classify_rate_limit(&usage, 90.0).is_some());
-    }
-
-    // ---- generate_session_hash ----
-
-    #[test]
-    fn session_hash_is_deterministic_for_same_input() {
-        let ua = "claude-cli/2.1.81 (external, cli)";
-        let body = json!({
-            "system": "You are Claude Code",
-            "messages": [{"role": "user", "content": "hello"}],
-        });
-        let h1 = generate_session_hash(ua, &body, ClientType::API);
-        let h2 = generate_session_hash(ua, &body, ClientType::API);
-        assert_eq!(
-            h1, h2,
-            "same (ua, content) must yield identical hash — sticky TTL depends on this"
-        );
-        assert_eq!(h1.len(), 32, "hex of 16-byte prefix should be 32 chars");
-    }
-
-    #[test]
-    fn session_hash_differs_by_system_prompt() {
-        let ua = "claude-cli/2.1.81";
-        let a = json!({"system": "prompt-A", "messages": [{"role": "user", "content": "x"}]});
-        let b = json!({"system": "prompt-B", "messages": [{"role": "user", "content": "x"}]});
-        assert_ne!(
-            generate_session_hash(ua, &a, ClientType::API),
-            generate_session_hash(ua, &b, ClientType::API)
-        );
-    }
-
-    #[test]
-    fn session_hash_falls_back_to_first_message_when_no_system() {
-        let ua = "claude-cli/2.1.81";
-        let a = json!({"messages": [{"role": "user", "content": "alpha"}]});
-        let b = json!({"messages": [{"role": "user", "content": "beta"}]});
-        let ha = generate_session_hash(ua, &a, ClientType::API);
-        let hb = generate_session_hash(ua, &b, ClientType::API);
-        assert_ne!(ha, hb);
-    }
-
-    #[test]
-    fn session_hash_no_longer_embeds_hour_window() {
-        // 回归测试：哈希不应在任何形式上依赖当前时间。
-        // 以前的实现把 Utc::now().format("%Y-%m-%dT%H") 拼到原文里，使 sticky TTL 被截断到 1 小时。
-        let ua = "claude-cli/2.1.81";
-        let body = json!({
-            "system": "stable-prompt",
-            "messages": [{"role": "user", "content": "hi"}],
-        });
-        // 哈希在极短时间内多次调用必须相同（这是显而易见的，但如果再次引入 Utc::now()，跨小时会翻车）。
-        let mut seen = std::collections::HashSet::new();
-        for _ in 0..10 {
-            seen.insert(generate_session_hash(ua, &body, ClientType::API));
-        }
-        assert_eq!(
-            seen.len(),
-            1,
-            "hash must be pure function of (ua, content); any time dependency is a regression"
-        );
-
-        // 进一步：已知等价输入的哈希必须等于已预计算的 sha256 前 16 字节 hex。
-        let expected = {
-            let raw = format!("{}|{}", ua, "stable-prompt");
-            let digest = Sha256::digest(raw.as_bytes());
-            hex::encode(&digest[..16])
-        };
-        assert_eq!(
-            generate_session_hash(ua, &body, ClientType::API),
-            expected,
-            "hash formula must be exactly sha256(ua|content)[..16] with no extra inputs"
-        );
-    }
-
-    #[test]
-    fn session_hash_cc_mode_uses_session_id_from_metadata() {
-        let ua = "claude-cli/2.1.81";
-        let body = json!({
-            "metadata": {
-                "user_id": "{\"session_id\":\"sess-abc-123\",\"account_id\":\"xyz\"}"
-            }
-        });
-        let h = generate_session_hash(ua, &body, ClientType::ClaudeCode);
-        assert_eq!(h, "sess-abc-123");
     }
 }

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -7,6 +7,7 @@ use futures_core::Stream;
 use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 use tracing::{debug, warn};
 
@@ -88,6 +89,7 @@ pub struct GatewayService {
     account_svc: Arc<AccountService>,
     rewriter: Arc<Rewriter>,
     telemetry_svc: Arc<TelemetryService>,
+    pub quarantine_on_429: Arc<AtomicBool>,
 }
 
 impl GatewayService {
@@ -95,11 +97,13 @@ impl GatewayService {
         account_svc: Arc<AccountService>,
         rewriter: Arc<Rewriter>,
         telemetry_svc: Arc<TelemetryService>,
+        quarantine_on_429: Arc<AtomicBool>,
     ) -> Self {
         Self {
             account_svc,
             rewriter,
             telemetry_svc,
+            quarantine_on_429,
         }
     }
 
@@ -347,7 +351,7 @@ impl GatewayService {
         // 处理限速：429 根据账号类型分别处理
         // - SetupToken: 保守 5h 限流
         // - OAuth: 查用量判断是撞墙（5h / 7d）还是纯 rate limit，分别设置限流时长
-        if status_code == 429 {
+        if status_code == 429 && self.quarantine_on_429.load(Ordering::Relaxed) {
             if let Err(e) = self.account_svc.handle_rate_limit(account).await {
                 warn!(
                     "failed to handle rate limit for account {}: {}",

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -5,3 +5,4 @@ pub mod oauth_flow;
 pub mod rewriter;
 pub mod telemetry;
 pub mod usage_poller;
+pub mod warmup_scheduler;

--- a/src/service/oauth.rs
+++ b/src/service/oauth.rs
@@ -46,6 +46,17 @@ impl TokenTester {
         proxy_url: &str,
         canonical_env: &Value,
     ) -> Result<(), AppError> {
+        self.test_token_with_message(token, proxy_url, canonical_env, "hi")
+            .await
+    }
+
+    pub async fn test_token_with_message(
+        &self,
+        token: &str,
+        proxy_url: &str,
+        canonical_env: &Value,
+        message: &str,
+    ) -> Result<(), AppError> {
         let env: CanonicalEnvData =
             serde_json::from_value(canonical_env.clone()).unwrap_or_default();
         let version = if env.version.is_empty() {
@@ -62,7 +73,7 @@ impl TokenTester {
         let body = serde_json::json!({
             "model": "claude-haiku-4-5-20251001",
             "max_tokens": 1,
-            "messages": [{"role": "user", "content": "hi"}]
+            "messages": [{"role": "user", "content": message}]
         });
 
         let client = make_request_client(proxy_url);
@@ -73,9 +84,15 @@ impl TokenTester {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", "oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05")
+            .header(
+                "anthropic-beta",
+                "oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05",
+            )
             .header("anthropic-dangerous-direct-browser-access", "true")
-            .header("User-Agent", format!("claude-cli/{} (external, cli)", version))
+            .header(
+                "User-Agent",
+                format!("claude-cli/{} (external, cli)", version),
+            )
             .header("x-app", "cli")
             .header("accept-encoding", "gzip, deflate, br, zstd")
             .header("X-Stainless-Lang", "js")

--- a/src/service/warmup_scheduler.rs
+++ b/src/service/warmup_scheduler.rs
@@ -1,0 +1,540 @@
+use std::fs;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Days, Utc};
+use rand::Rng;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::config::WarmupConfig;
+use crate::model::account::{Account, AccountStatus};
+use crate::service::account::AccountService;
+use crate::service::oauth::TokenTester;
+use crate::store::account_store::AccountStore;
+use crate::store::cache::CacheStore;
+use crate::store::settings_store::SettingsStore;
+
+const WARMUP_LOCK_TTL: Duration = Duration::from_secs(15 * 60);
+const SAME_DAY_MIN_DELAY_SECONDS: i64 = 60;
+
+#[derive(Clone, Debug)]
+pub struct WarmupSettings {
+    pub enabled: bool,
+    pub base_utc_hour: u32,
+    pub jitter_minutes: i64,
+    pub max_retries: u32,
+    pub retry_backoff_secs: u64,
+    pub account_gap_secs: u64,
+    pub poll_interval_secs: u64,
+}
+
+impl WarmupSettings {
+    pub fn from_defaults(defaults: &WarmupConfig) -> Self {
+        Self {
+            enabled: defaults.enabled,
+            base_utc_hour: defaults.base_utc_hour.min(23),
+            jitter_minutes: defaults.jitter_minutes.clamp(0, 720),
+            max_retries: defaults.max_retries.min(10),
+            retry_backoff_secs: defaults.retry_backoff_secs.max(30),
+            account_gap_secs: defaults.account_gap_secs.max(1),
+            poll_interval_secs: defaults.poll_interval_secs.max(15),
+        }
+    }
+}
+
+pub struct WarmupSchedulerService {
+    account_store: Arc<AccountStore>,
+    account_svc: Arc<AccountService>,
+    cache: Arc<dyn CacheStore>,
+    settings_store: Arc<SettingsStore>,
+    token_tester: Arc<TokenTester>,
+    defaults: WarmupConfig,
+}
+
+impl WarmupSchedulerService {
+    pub fn new(
+        account_store: Arc<AccountStore>,
+        account_svc: Arc<AccountService>,
+        cache: Arc<dyn CacheStore>,
+        settings_store: Arc<SettingsStore>,
+        token_tester: Arc<TokenTester>,
+        defaults: WarmupConfig,
+    ) -> Self {
+        Self {
+            account_store,
+            account_svc,
+            cache,
+            settings_store,
+            token_tester,
+            defaults,
+        }
+    }
+
+    pub async fn run(self: Arc<Self>) {
+        info!("warmup scheduler: started");
+        loop {
+            let settings = self.load_settings().await;
+            if settings.enabled {
+                if let Err(err) = self.tick(&settings).await {
+                    warn!("warmup scheduler: tick failed: {}", err);
+                }
+            }
+            sleep(Duration::from_secs(settings.poll_interval_secs)).await;
+        }
+    }
+
+    async fn load_settings(&self) -> WarmupSettings {
+        let mut settings = WarmupSettings::from_defaults(&self.defaults);
+
+        if let Ok(Some(value)) = self.settings_store.get("warmup_enabled").await {
+            settings.enabled = value != "false";
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_base_utc_hour").await {
+            if let Ok(hour) = value.parse::<u32>() {
+                settings.base_utc_hour = hour.min(23);
+            }
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_jitter_minutes").await {
+            if let Ok(minutes) = value.parse::<i64>() {
+                settings.jitter_minutes = minutes.clamp(0, 720);
+            }
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_max_retries").await {
+            if let Ok(retries) = value.parse::<u32>() {
+                settings.max_retries = retries.min(10);
+            }
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_retry_backoff_secs").await {
+            if let Ok(secs) = value.parse::<u64>() {
+                settings.retry_backoff_secs = secs.max(30);
+            }
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_account_gap_secs").await {
+            if let Ok(secs) = value.parse::<u64>() {
+                settings.account_gap_secs = secs.max(1);
+            }
+        }
+        if let Ok(Some(value)) = self.settings_store.get("warmup_poll_interval_secs").await {
+            if let Ok(secs) = value.parse::<u64>() {
+                settings.poll_interval_secs = secs.max(15);
+            }
+        }
+
+        settings
+    }
+
+    async fn tick(&self, settings: &WarmupSettings) -> Result<(), String> {
+        let now = Utc::now();
+        let accounts = self
+            .account_svc
+            .list_accounts()
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut due_accounts = Vec::new();
+
+        for account in accounts
+            .into_iter()
+            .filter(|account| account.warmup_enabled && account.status == AccountStatus::Active)
+        {
+            let refreshed = self.ensure_schedule(account, settings, now).await?;
+            if refreshed
+                .next_warmup_at
+                .map(|ts| ts <= now)
+                .unwrap_or(false)
+            {
+                due_accounts.push(refreshed);
+            }
+        }
+
+        due_accounts.sort_by_key(|account| account.next_warmup_at);
+
+        let due_len = due_accounts.len();
+        for (idx, account) in due_accounts.into_iter().enumerate() {
+            self.run_warmup(account, settings, now).await;
+            if idx + 1 < due_len {
+                let gap = random_account_gap(settings.account_gap_secs);
+                sleep(Duration::from_secs(gap)).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn ensure_schedule(
+        &self,
+        mut account: Account,
+        settings: &WarmupSettings,
+        now: DateTime<Utc>,
+    ) -> Result<Account, String> {
+        if account.next_warmup_at.is_some() {
+            return Ok(account);
+        }
+
+        let next = next_scheduled_warmup(now, settings, 0);
+        self.account_store
+            .update_warmup_state(
+                account.id,
+                Some(next),
+                account.last_warmup_at,
+                &account.last_warmup_status,
+                &account.last_warmup_message,
+                0,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        account.next_warmup_at = Some(next);
+        account.warmup_retry_count = 0;
+        Ok(account)
+    }
+
+    async fn run_warmup(&self, account: Account, settings: &WarmupSettings, now: DateTime<Utc>) {
+        let lock_key = format!("warmup:account:{}", account.id);
+        let lock_owner = Uuid::new_v4().to_string();
+        let acquired = match self
+            .cache
+            .acquire_lock(&lock_key, &lock_owner, WARMUP_LOCK_TTL)
+            .await
+        {
+            Ok(acquired) => acquired,
+            Err(err) => {
+                warn!(
+                    "warmup scheduler: account {} lock failed: {}",
+                    account.id, err
+                );
+                return;
+            }
+        };
+        if !acquired {
+            debug!(
+                "warmup scheduler: account {} skipped because another instance holds the lock",
+                account.id
+            );
+            return;
+        }
+
+        let message = random_greeting(&self.defaults.greetings_file);
+        debug!(
+            "warmup scheduler: warming account {} at {}",
+            account.id,
+            now.to_rfc3339()
+        );
+
+        let token = match self.account_svc.resolve_upstream_token(account.id).await {
+            Ok(token) => token,
+            Err(err) => {
+                self.handle_failure(account, settings, now, &message, &err.to_string())
+                    .await;
+                self.cache.release_lock(&lock_key, &lock_owner).await;
+                return;
+            }
+        };
+
+        match self
+            .token_tester
+            .test_token_with_message(&token, &account.proxy_url, &account.canonical_env, &message)
+            .await
+        {
+            Ok(()) => {
+                let next = next_scheduled_warmup(now, settings, 1);
+                if let Err(err) = self
+                    .account_store
+                    .update_warmup_state(account.id, Some(next), Some(now), "ok", &message, 0)
+                    .await
+                {
+                    warn!(
+                        "warmup scheduler: update success state failed for account {}: {}",
+                        account.id, err
+                    );
+                }
+            }
+            Err(err) => {
+                self.handle_failure(account, settings, now, &message, &err.to_string())
+                    .await;
+            }
+        }
+
+        self.cache.release_lock(&lock_key, &lock_owner).await;
+    }
+
+    async fn handle_failure(
+        &self,
+        account: Account,
+        settings: &WarmupSettings,
+        now: DateTime<Utc>,
+        message: &str,
+        err: &str,
+    ) {
+        let current_retry = account.warmup_retry_count.max(0) as u32;
+        let status = format!("error: {}", err);
+        let (next, retry_count) = if current_retry < settings.max_retries {
+            (
+                Some(now + chrono::Duration::seconds(settings.retry_backoff_secs as i64)),
+                (current_retry + 1) as i32,
+            )
+        } else {
+            (Some(next_scheduled_warmup(now, settings, 1)), 0)
+        };
+
+        if let Err(store_err) = self
+            .account_store
+            .update_warmup_state(account.id, next, Some(now), &status, message, retry_count)
+            .await
+        {
+            warn!(
+                "warmup scheduler: update failure state failed for account {}: {}",
+                account.id, store_err
+            );
+        }
+    }
+}
+
+pub fn next_scheduled_warmup(
+    now: DateTime<Utc>,
+    settings: &WarmupSettings,
+    day_offset: u64,
+) -> DateTime<Utc> {
+    let target_date = now
+        .date_naive()
+        .checked_add_days(Days::new(day_offset))
+        .unwrap_or(now.date_naive());
+    let base = target_date
+        .and_hms_opt(settings.base_utc_hour, 0, 0)
+        .unwrap()
+        .and_utc();
+    let window_start = base - chrono::Duration::minutes(settings.jitter_minutes);
+    let window_end = base + chrono::Duration::minutes(settings.jitter_minutes);
+
+    if day_offset == 0 {
+        if now < window_start {
+            return random_datetime_between(window_start, window_end);
+        }
+        if now < window_end {
+            let earliest = (now + chrono::Duration::seconds(SAME_DAY_MIN_DELAY_SECONDS))
+                .min(window_end);
+            return random_datetime_between(earliest, window_end);
+        }
+        return next_scheduled_warmup(now, settings, 1);
+    }
+
+    random_datetime_between(window_start, window_end)
+}
+
+fn random_account_gap(base_secs: u64) -> u64 {
+    if base_secs <= 1 {
+        return base_secs;
+    }
+    let mut rng = rand::thread_rng();
+    let jitter = (base_secs / 3).max(1);
+    let min = base_secs.saturating_sub(jitter);
+    let max = base_secs + jitter;
+    rng.gen_range(min..=max)
+}
+
+fn random_greeting(greetings_file: &str) -> String {
+    const GREETINGS: &[&str] = &[
+        "晚上好",
+        "你好",
+        "嗨",
+        "晚上好呀",
+        "你好呀",
+        "在吗",
+        "晚上好，打个招呼",
+        "你好，来问候一下",
+        "嗨，随手发一句",
+        "晚上好，随便说一句",
+        "你好，先问个好",
+        "晚上好，冒个泡",
+        "嗨，来打个招呼",
+        "你好，路过问候一下",
+        "晚上好，先发一句",
+        "你好，简单问候一下",
+        "嗨，先说声你好",
+        "晚上好，来冒个泡",
+        "你好，顺手发一句",
+        "晚上好，先打个卡",
+        "嗨，晚上好",
+        "你好，来露个面",
+        "晚上好，来问个好",
+        "你好，发个招呼",
+        "嗨，问候一下",
+        "晚上好，过来打个招呼",
+        "你好，先冒个泡",
+        "嗨，先留一句",
+        "晚上好，先问候一下",
+        "你好，先来一句",
+        "嗨，晚上来打个招呼",
+        "晚上好，随手问候一下",
+        "你好，轻轻发一句",
+        "嗨，来问个好",
+        "晚上好，先露个面",
+        "你好，打个招呼就走",
+        "嗨，来打声招呼",
+        "晚上好，先发个你好",
+        "你好，来留个言",
+        "嗨，简单打个招呼",
+        "晚上好，先说句你好",
+        "你好，过来问候一声",
+        "嗨，顺手来一句",
+        "晚上好，发个问候",
+        "你好，来报个到",
+        "嗨，先打个照面",
+        "晚上好，先留一句话",
+        "你好，先轻轻问候一下",
+        "嗨，发个小招呼",
+        "晚上好，来随手问候一下",
+    ];
+
+    if let Some(greetings) = load_greetings_from_file(greetings_file) {
+        let mut rng = rand::thread_rng();
+        return greetings[rng.gen_range(0..greetings.len())].clone();
+    }
+
+    let mut rng = rand::thread_rng();
+    GREETINGS[rng.gen_range(0..GREETINGS.len())].to_string()
+}
+
+fn load_greetings_from_file(path: &str) -> Option<Vec<String>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) => {
+            debug!("warmup scheduler: failed to read greetings file {}: {}", path, err);
+            return None;
+        }
+    };
+    let greetings = parse_greetings(&content);
+    if greetings.is_empty() {
+        debug!("warmup scheduler: greetings file {} is empty after parsing", path);
+        return None;
+    }
+    Some(greetings)
+}
+
+fn parse_greetings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(normalize_greeting_line)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect()
+}
+
+fn normalize_greeting_line(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn random_datetime_between(start: DateTime<Utc>, end: DateTime<Utc>) -> DateTime<Utc> {
+    if end <= start {
+        return start;
+    }
+    let mut rng = rand::thread_rng();
+    let span = (end - start).num_seconds();
+    start + chrono::Duration::seconds(rng.gen_range(0..=span))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    #[test]
+    fn next_schedule_stays_in_window() {
+        let settings = WarmupSettings {
+            enabled: true,
+            base_utc_hour: 23,
+            jitter_minutes: 30,
+            max_retries: 2,
+            retry_backoff_secs: 300,
+            account_gap_secs: 45,
+            poll_interval_secs: 60,
+        };
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(20, 0, 0)
+            .unwrap()
+            .and_utc();
+        let scheduled = next_scheduled_warmup(now, &settings, 0);
+        let earliest = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(22, 30, 0)
+            .unwrap()
+            .and_utc();
+        let latest = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(23, 30, 0)
+            .unwrap()
+            .and_utc();
+        assert!(scheduled >= earliest);
+        assert!(scheduled <= latest);
+    }
+
+    #[test]
+    fn next_schedule_rolls_forward_after_window() {
+        let settings = WarmupSettings {
+            enabled: true,
+            base_utc_hour: 23,
+            jitter_minutes: 0,
+            max_retries: 2,
+            retry_backoff_secs: 300,
+            account_gap_secs: 45,
+            poll_interval_secs: 60,
+        };
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(23, 5, 0)
+            .unwrap()
+            .and_utc();
+        let scheduled = next_scheduled_warmup(now, &settings, 0);
+        assert_eq!(scheduled.date_naive(), now.date_naive().succ_opt().unwrap());
+        assert_eq!(scheduled.hour(), 23);
+    }
+
+    #[test]
+    fn next_schedule_uses_remaining_time_when_window_is_open() {
+        let settings = WarmupSettings {
+            enabled: true,
+            base_utc_hour: 23,
+            jitter_minutes: 30,
+            max_retries: 2,
+            retry_backoff_secs: 300,
+            account_gap_secs: 45,
+            poll_interval_secs: 60,
+        };
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(22, 45, 0)
+            .unwrap()
+            .and_utc();
+        let scheduled = next_scheduled_warmup(now, &settings, 0);
+        let earliest = now + chrono::Duration::seconds(SAME_DAY_MIN_DELAY_SECONDS);
+        let latest = chrono::NaiveDate::from_ymd_opt(2026, 4, 16)
+            .unwrap()
+            .and_hms_opt(23, 30, 0)
+            .unwrap()
+            .and_utc();
+        assert_eq!(scheduled.date_naive(), now.date_naive());
+        assert!(scheduled >= earliest);
+        assert!(scheduled <= latest);
+    }
+
+    #[test]
+    fn parse_greetings_ignores_comments_and_blank_lines() {
+        let parsed = parse_greetings(
+            "
+            # comment
+            晚上好
+
+            你好
+            ",
+        );
+
+        assert_eq!(parsed, vec!["晚上好".to_string(), "你好".to_string()]);
+    }
+
+    #[test]
+    fn parse_greetings_normalizes_whitespace() {
+        let parsed = parse_greetings("  晚上好呀   \n你   好  呀\n");
+
+        assert_eq!(parsed, vec!["晚上好呀".to_string(), "你 好 呀".to_string()]);
+    }
+}

--- a/src/store/account_store.rs
+++ b/src/store/account_store.rs
@@ -74,14 +74,7 @@ impl AccountStore {
                     .ok()
             })
             .or_else(|| {
-                // PG TIMESTAMPTZ::text 完整格式: "2026-04-16 12:30:45.123456+08:00"
                 DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f%:z")
-                    .map(|dt| dt.with_timezone(&Utc))
-                    .ok()
-            })
-            .or_else(|| {
-                // PG TIMESTAMPTZ::text 短时区格式: "2026-04-16 12:30:45+08"
-                DateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%#z")
                     .map(|dt| dt.with_timezone(&Utc))
                     .ok()
             })
@@ -116,14 +109,6 @@ impl AccountStore {
             ACCOUNT_COLS_PG_TEXT
         } else {
             ACCOUNT_COLS
-        }
-    }
-
-    fn returning_account_timestamps(&self) -> &'static str {
-        if self.is_pg() {
-            "id, created_at::text AS created_at, updated_at::text AS updated_at"
-        } else {
-            "id, created_at, updated_at"
         }
     }
 
@@ -175,6 +160,16 @@ impl AccountStore {
                 .unwrap_or_default(),
             auto_telemetry: row.try_get::<i32, _>("auto_telemetry").unwrap_or(0) != 0,
             telemetry_count: row.try_get::<i64, _>("telemetry_count").unwrap_or(0),
+            warmup_enabled: row.try_get::<i32, _>("warmup_enabled").unwrap_or(0) != 0,
+            next_warmup_at: Self::parse_optional_time(row, "next_warmup_at"),
+            last_warmup_at: Self::parse_optional_time(row, "last_warmup_at"),
+            last_warmup_status: row
+                .try_get::<String, _>("last_warmup_status")
+                .unwrap_or_default(),
+            last_warmup_message: row
+                .try_get::<String, _>("last_warmup_message")
+                .unwrap_or_default(),
+            warmup_retry_count: row.try_get::<i32, _>("warmup_retry_count").unwrap_or(0),
             usage_data: Self::parse_json(row, "usage_data"),
             usage_fetched_at: Self::parse_optional_time(row, "usage_fetched_at"),
             created_at: Self::parse_time(row, "created_at"),
@@ -209,9 +204,8 @@ impl AccountStore {
                 auth_type, access_token, refresh_token, oauth_expires_at, oauth_refreshed_at, auth_error,
                 device_id, canonical_env, canonical_prompt_env, canonical_process,
                 billing_mode, account_uuid, organization_uuid, subscription_type,
-                concurrency, priority, auto_telemetry)
-            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,{},{},{},$12,{},{},{},$16,{},{},{},$20,$21,$22)
-            RETURNING {}"#,
+                concurrency, priority, auto_telemetry, warmup_enabled)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,{},{},{},$12,{},{},{},$16,{},{},{},$20,$21,$22,$23)"#,
             self.nullable_ts(9),
             self.nullable_ts(10),
             "$11",
@@ -220,10 +214,9 @@ impl AccountStore {
             self.jsonb(15),
             self.nullable(17),
             self.nullable(18),
-            self.nullable(19),
-            self.returning_account_timestamps()
+            self.nullable(19)
         );
-        let row: AnyRow = sqlx::query(&q)
+        sqlx::query(&q)
             .bind(&a.name)
             .bind(&a.email)
             .bind(a.status.to_string())
@@ -246,8 +239,17 @@ impl AccountStore {
             .bind(a.concurrency)
             .bind(a.priority)
             .bind(auto_telemetry_int)
-            .fetch_one(&self.pool)
+            .bind(if a.warmup_enabled { 1 } else { 0 })
+            .execute(&self.pool)
             .await?;
+
+        let row: AnyRow = sqlx::query(&format!(
+            "SELECT {} FROM accounts WHERE email=$1",
+            self.select_account_cols()
+        ))
+        .bind(&a.email)
+        .fetch_one(&self.pool)
+        .await?;
 
         a.id = row.try_get::<i64, _>("id").unwrap_or_default();
         a.created_at = Self::parse_time(&row, "created_at");
@@ -264,8 +266,8 @@ impl AccountStore {
                 auth_type=$5, access_token=$6, refresh_token=$7, oauth_expires_at={}, oauth_refreshed_at={},
                 auth_error=$10, proxy_url=$11, billing_mode=$12,
                 account_uuid={}, organization_uuid={}, subscription_type={},
-                concurrency=$16, priority=$17, auto_telemetry=$18, updated_at={}
-            WHERE id=$19"#,
+                concurrency=$16, priority=$17, auto_telemetry=$18, warmup_enabled=$19, updated_at={}
+            WHERE id=$20"#,
             self.nullable_ts(8),
             self.nullable_ts(9),
             self.nullable(13),
@@ -292,9 +294,47 @@ impl AccountStore {
             .bind(a.concurrency)
             .bind(a.priority)
             .bind(auto_telemetry_int)
+            .bind(if a.warmup_enabled { 1 } else { 0 })
             .bind(a.id)
             .execute(&self.pool)
             .await?;
+        Ok(())
+    }
+
+    pub async fn update_warmup_state(
+        &self,
+        id: i64,
+        next_warmup_at: Option<DateTime<Utc>>,
+        last_warmup_at: Option<DateTime<Utc>>,
+        last_warmup_status: &str,
+        last_warmup_message: &str,
+        warmup_retry_count: i32,
+    ) -> Result<(), AppError> {
+        let q = format!(
+            "UPDATE accounts SET next_warmup_at={}, last_warmup_at={}, last_warmup_status=$3, \
+             last_warmup_message=$4, warmup_retry_count=$5, updated_at={} WHERE id=$6",
+            self.nullable_ts(1),
+            self.nullable_ts(2),
+            self.now_expr()
+        );
+        sqlx::query(&q)
+            .bind(next_warmup_at.map(|t| self.fmt_time(t)))
+            .bind(last_warmup_at.map(|t| self.fmt_time(t)))
+            .bind(last_warmup_status)
+            .bind(last_warmup_message)
+            .bind(warmup_retry_count)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn clear_warmup_state(&self, id: i64) -> Result<(), AppError> {
+        let q = format!(
+            "UPDATE accounts SET next_warmup_at=NULL, warmup_retry_count=0, updated_at={} WHERE id=$1",
+            self.now_expr()
+        );
+        sqlx::query(&q).bind(id).execute(&self.pool).await?;
         Ok(())
     }
 
@@ -514,6 +554,8 @@ const ACCOUNT_COLS: &str = r#"id, name, email, status, token, auth_type, access_
     billing_mode, account_uuid, organization_uuid, subscription_type,
     concurrency, priority, rate_limited_at, rate_limit_reset_at,
     disable_reason, auto_telemetry, telemetry_count,
+    warmup_enabled, next_warmup_at, last_warmup_at, last_warmup_status,
+    last_warmup_message, warmup_retry_count,
     usage_data, usage_fetched_at, created_at, updated_at"#;
 
 const ACCOUNT_COLS_PG_TEXT: &str = r#"id, name, email, status, token, auth_type, access_token, refresh_token,
@@ -525,6 +567,9 @@ const ACCOUNT_COLS_PG_TEXT: &str = r#"id, name, email, status, token, auth_type,
     concurrency, priority, rate_limited_at::text AS rate_limited_at,
     rate_limit_reset_at::text AS rate_limit_reset_at,
     disable_reason, auto_telemetry, telemetry_count,
+    warmup_enabled, next_warmup_at::text AS next_warmup_at,
+    last_warmup_at::text AS last_warmup_at, last_warmup_status,
+    last_warmup_message, warmup_retry_count,
     usage_data::text AS usage_data, usage_fetched_at::text AS usage_fetched_at,
     created_at::text AS created_at, updated_at::text AS updated_at"#;
 

--- a/src/store/db.rs
+++ b/src/store/db.rs
@@ -58,7 +58,11 @@ pub async fn migrate(pool: &AnyPool, driver: &str) -> Result<(), sqlx::Error> {
         sqlx::query(stmt).execute(pool).await?;
     }
     // 增量迁移 — use correct PG types for TIMESTAMPTZ / JSONB columns
-    let ts_type = if driver == "sqlite" { "TEXT" } else { "TIMESTAMPTZ" };
+    let ts_type = if driver == "sqlite" {
+        "TEXT"
+    } else {
+        "TIMESTAMPTZ"
+    };
     let json_type = if driver == "sqlite" { "TEXT" } else { "JSONB" };
 
     sqlx::query("ALTER TABLE accounts ADD COLUMN billing_mode TEXT NOT NULL DEFAULT 'strip'")
@@ -133,13 +137,74 @@ pub async fn migrate(pool: &AnyPool, driver: &str) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await
         .ok();
+    sqlx::query("ALTER TABLE accounts ADD COLUMN warmup_enabled INTEGER NOT NULL DEFAULT 0")
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query(&format!(
+        "ALTER TABLE accounts ADD COLUMN next_warmup_at {}",
+        ts_type
+    ))
+    .execute(pool)
+    .await
+    .ok();
+    sqlx::query(&format!(
+        "ALTER TABLE accounts ADD COLUMN last_warmup_at {}",
+        ts_type
+    ))
+    .execute(pool)
+    .await
+    .ok();
+    sqlx::query("ALTER TABLE accounts ADD COLUMN last_warmup_status TEXT NOT NULL DEFAULT ''")
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE accounts ADD COLUMN last_warmup_message TEXT NOT NULL DEFAULT ''")
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE accounts ADD COLUMN warmup_retry_count INTEGER NOT NULL DEFAULT 0")
+        .execute(pool)
+        .await
+        .ok();
+
+    let settings_schema = if driver == "sqlite" {
+        SQLITE_SETTINGS_SCHEMA
+    } else {
+        PG_SETTINGS_SCHEMA
+    };
+    for stmt in settings_schema.split(';') {
+        let stmt = stmt.trim();
+        if stmt.is_empty() {
+            continue;
+        }
+        sqlx::query(stmt).execute(pool).await?;
+    }
+    if driver == "sqlite" {
+        sqlx::query(
+            "INSERT OR IGNORE INTO settings (key, value) VALUES ('quarantine_on_429', 'true')",
+        )
+        .execute(pool)
+        .await
+        .ok();
+    } else {
+        sqlx::query(
+            "INSERT INTO settings (key, value) VALUES ('quarantine_on_429', 'true') \
+             ON CONFLICT (key) DO NOTHING",
+        )
+        .execute(pool)
+        .await
+        .ok();
+    }
 
     // Fix column types for existing PG databases that may have TEXT instead of TIMESTAMPTZ/JSONB
     if driver != "sqlite" {
-        sqlx::query("ALTER TABLE accounts ALTER COLUMN usage_data TYPE JSONB USING usage_data::JSONB")
-            .execute(pool)
-            .await
-            .ok();
+        sqlx::query(
+            "ALTER TABLE accounts ALTER COLUMN usage_data TYPE JSONB USING usage_data::JSONB",
+        )
+        .execute(pool)
+        .await
+        .ok();
         sqlx::query("ALTER TABLE accounts ALTER COLUMN usage_fetched_at TYPE TIMESTAMPTZ USING usage_fetched_at::TIMESTAMPTZ")
             .execute(pool)
             .await
@@ -149,6 +214,14 @@ pub async fn migrate(pool: &AnyPool, driver: &str) -> Result<(), sqlx::Error> {
             .await
             .ok();
         sqlx::query("ALTER TABLE accounts ALTER COLUMN oauth_refreshed_at TYPE TIMESTAMPTZ USING oauth_refreshed_at::TIMESTAMPTZ")
+            .execute(pool)
+            .await
+            .ok();
+        sqlx::query("ALTER TABLE accounts ALTER COLUMN next_warmup_at TYPE TIMESTAMPTZ USING next_warmup_at::TIMESTAMPTZ")
+            .execute(pool)
+            .await
+            .ok();
+        sqlx::query("ALTER TABLE accounts ALTER COLUMN last_warmup_at TYPE TIMESTAMPTZ USING last_warmup_at::TIMESTAMPTZ")
             .execute(pool)
             .await
             .ok();
@@ -199,6 +272,12 @@ CREATE TABLE IF NOT EXISTS accounts (
     disable_reason       TEXT NOT NULL DEFAULT '',
     auto_telemetry       INTEGER NOT NULL DEFAULT 0,
     telemetry_count      INTEGER NOT NULL DEFAULT 0,
+    warmup_enabled       INTEGER NOT NULL DEFAULT 0,
+    next_warmup_at       TEXT,
+    last_warmup_at       TEXT,
+    last_warmup_status   TEXT NOT NULL DEFAULT '',
+    last_warmup_message  TEXT NOT NULL DEFAULT '',
+    warmup_retry_count   INTEGER NOT NULL DEFAULT 0,
     usage_data           TEXT NOT NULL DEFAULT '{}',
     usage_fetched_at     TEXT,
     created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
@@ -236,12 +315,32 @@ CREATE TABLE IF NOT EXISTS accounts (
     disable_reason       TEXT NOT NULL DEFAULT '',
     auto_telemetry       INT NOT NULL DEFAULT 0,
     telemetry_count      BIGINT NOT NULL DEFAULT 0,
+    warmup_enabled       INT NOT NULL DEFAULT 0,
+    next_warmup_at       TIMESTAMPTZ,
+    last_warmup_at       TIMESTAMPTZ,
+    last_warmup_status   TEXT NOT NULL DEFAULT '',
+    last_warmup_message  TEXT NOT NULL DEFAULT '',
+    warmup_retry_count   INT NOT NULL DEFAULT 0,
     usage_data           JSONB NOT NULL DEFAULT '{}',
     usage_fetched_at     TIMESTAMPTZ,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+"#;
+
+const SQLITE_SETTINGS_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"#;
+
+const PG_SETTINGS_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
 "#;
 
 const SQLITE_TOKENS_SCHEMA: &str = r#"

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -3,4 +3,5 @@ pub mod cache;
 pub mod db;
 pub mod memory;
 pub mod redis;
+pub mod settings_store;
 pub mod token_store;

--- a/src/store/settings_store.rs
+++ b/src/store/settings_store.rs
@@ -1,0 +1,37 @@
+use sqlx::AnyPool;
+
+use crate::error::AppError;
+
+pub struct SettingsStore {
+    pool: AnyPool,
+}
+
+impl SettingsStore {
+    pub fn new(pool: AnyPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn get(&self, key: &str) -> Result<Option<String>, AppError> {
+        use sqlx::Row;
+
+        let row = sqlx::query("SELECT value FROM settings WHERE key=$1")
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        Ok(row.map(|r| r.get::<String, _>("value")))
+    }
+
+    pub async fn set(&self, key: &str, value: &str) -> Result<(), AppError> {
+        sqlx::query(
+            "INSERT INTO settings (key, value) VALUES ($1, $2) \
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -52,6 +52,12 @@ export interface Account {
   priority: number
   auto_telemetry: boolean
   telemetry_count: number
+  warmup_enabled: boolean
+  next_warmup_at?: string
+  last_warmup_at?: string
+  last_warmup_status?: string
+  last_warmup_message?: string
+  warmup_retry_count: number
   telemetry_expires_at?: string
   rate_limited_at?: string
   rate_limit_reset_at?: string
@@ -97,6 +103,17 @@ export interface Dashboard {
   tokens: number;
 }
 
+export interface Settings {
+  quarantine_on_429: boolean
+  warmup_enabled: boolean
+  warmup_base_utc_hour: number
+  warmup_jitter_minutes: number
+  warmup_max_retries: number
+  warmup_retry_backoff_secs: number
+  warmup_account_gap_secs: number
+  warmup_poll_interval_secs: number
+}
+
 export interface OAuthGenerateResult {
   auth_url: string;
   session_id: string;
@@ -136,4 +153,7 @@ export const api = {
     request<OAuthExchangeResult>('POST', '/admin/oauth/exchange-code', { session_id: sessionId, code }),
   exchangeSetupTokenCode: (sessionId: string, code: string) =>
     request<OAuthExchangeResult>('POST', '/admin/oauth/exchange-setup-token-code', { session_id: sessionId, code }),
+  getSettings: () => request<Settings>('GET', '/admin/settings'),
+  updateSettings: (s: Partial<Settings>) =>
+    request<Settings>('PUT', '/admin/settings', s),
 }

--- a/web/src/components/Accounts.vue
+++ b/web/src/components/Accounts.vue
@@ -47,6 +47,7 @@ const form = ref({
   concurrency: 3,
   priority: 50,
   auto_telemetry: false,
+  warmup_enabled: false,
 });
 /** 正在测试的账号 ID */
 const testing = ref<number | null>(null);
@@ -123,6 +124,7 @@ function openCreate() {
     concurrency: 3,
     priority: 50,
     auto_telemetry: false,
+    warmup_enabled: false,
   };
   showForm.value = true;
 }
@@ -149,6 +151,7 @@ function openEdit(a: Account) {
     concurrency: a.concurrency,
     priority: a.priority,
     auto_telemetry: a.auto_telemetry ?? false,
+    warmup_enabled: a.warmup_enabled ?? false,
   };
   showForm.value = true;
 }
@@ -185,6 +188,7 @@ async function save() {
       updates.concurrency = form.value.concurrency;
       updates.priority = form.value.priority;
       updates.auto_telemetry = form.value.auto_telemetry;
+      updates.warmup_enabled = form.value.warmup_enabled;
       await api.updateAccount(editing.value.id, updates);
     } else {
       if (form.value.auth_type === 'setup_token' && !form.value.setup_token.trim()) {
@@ -208,6 +212,7 @@ async function save() {
         concurrency: form.value.concurrency,
         priority: form.value.priority,
         auto_telemetry: form.value.auto_telemetry,
+        warmup_enabled: form.value.warmup_enabled,
       };
       if (normalizedExpiresAt) payload.expires_at = normalizedExpiresAt;
       await api.createAccount(payload);
@@ -413,6 +418,33 @@ function formatBytes(bytes?: number): string {
   return bytes + 'B';
 }
 
+function formatDateTime(value?: string): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function warmupStatusClass(account: Account): string {
+  const status = account.last_warmup_status || '';
+  if (!account.warmup_enabled) return 'text-[#8c8475]';
+  if (status.startsWith('error:')) return 'text-red-500';
+  if (status === 'ok') return 'text-emerald-600';
+  return 'text-amber-600';
+}
+
+function warmupStatusLabel(account: Account): string {
+  if (!account.warmup_enabled) return '未参与';
+  const status = account.last_warmup_status || '';
+  if (status === 'ok') return '最近成功';
+  if (status.startsWith('error:')) return '最近失败';
+  if (account.next_warmup_at) return '等待执行';
+  return '未排程';
+}
+
 /** 切换认证方式 */
 function setAuthType(authType: 'setup_token' | 'oauth') {
   form.value.auth_type = authType;
@@ -502,6 +534,7 @@ function applyOAuthResult() {
     concurrency: 3,
     priority: 50,
     auto_telemetry: false,
+    warmup_enabled: false,
   };
   showForm.value = true;
 }
@@ -626,6 +659,29 @@ async function copyText(text: string) {
                 </p>
                 <p v-if="a.telemetry_expires_at" class="text-xs text-amber-500 mt-0.5">
                   遥测中 · 停止于 {{ new Date(a.telemetry_expires_at).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) }}
+                </p>
+              </div>
+              <div>
+                <p class="text-[10px] text-[#b5b0a6] uppercase tracking-wider mb-0.5">预热</p>
+                <p class="text-sm" :class="warmupStatusClass(a)">
+                  {{ a.warmup_enabled ? '已开启' : '关闭' }}
+                  <span class="text-[#b5b0a6] text-xs">· {{ warmupStatusLabel(a) }}</span>
+                  <span v-if="a.warmup_retry_count > 0" class="text-[#b5b0a6] text-xs">· 重试 {{ a.warmup_retry_count }} 次</span>
+                </p>
+                <p v-if="a.next_warmup_at" class="text-xs text-[#8c8475] mt-0.5">
+                  下次预热 · {{ formatDateTime(a.next_warmup_at) }}
+                </p>
+                <p v-if="a.last_warmup_at" class="text-xs text-[#8c8475] mt-0.5">
+                  最近执行 · {{ formatDateTime(a.last_warmup_at) }}
+                </p>
+                <p v-if="a.last_warmup_message" class="text-xs text-[#b5b0a6] mt-0.5 line-clamp-2">
+                  {{ a.last_warmup_message }}
+                </p>
+                <p
+                  v-if="a.last_warmup_status && a.last_warmup_status.startsWith('error:')"
+                  class="text-xs text-red-500 mt-0.5 line-clamp-2"
+                >
+                  {{ a.last_warmup_status }}
                 </p>
               </div>
               <div>
@@ -1043,6 +1099,32 @@ async function copyText(text: string) {
               </button>
             </div>
             <p class="text-xs text-[#b5b0a6]">开启后由网关代替客户端发送遥测请求</p>
+          </div>
+          <div class="space-y-2">
+            <Label class="text-[#5c5647] text-sm">预热计划</Label>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                @click="form.warmup_enabled = false"
+                class="flex-1 px-3 py-2 rounded-lg text-sm font-medium border transition-all duration-200"
+                :class="!form.warmup_enabled
+                  ? 'bg-[#f9f6f1] border-[#8c8475] text-[#5c5647]'
+                  : 'bg-[#f9f6f1] border-[#e8e2d9] text-[#8c8475] hover:border-[#8c8475]/40'"
+              >
+                不参与
+              </button>
+              <button
+                type="button"
+                @click="form.warmup_enabled = true"
+                class="flex-1 px-3 py-2 rounded-lg text-sm font-medium border transition-all duration-200"
+                :class="form.warmup_enabled
+                  ? 'bg-amber-50 border-amber-400 text-amber-600'
+                  : 'bg-[#f9f6f1] border-[#e8e2d9] text-[#8c8475] hover:border-amber-300'"
+              >
+                参与预热
+              </button>
+            </div>
+            <p class="text-xs text-[#b5b0a6]">开启后由后台按全局预热设置随机安排每日问候测试</p>
           </div>
           <div class="flex gap-4">
             <div class="flex-1 space-y-2">

--- a/web/src/components/Dashboard.vue
+++ b/web/src/components/Dashboard.vue
@@ -1,15 +1,25 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import { api, type Dashboard as DashboardData } from '../api';
+import { api, type Dashboard as DashboardData, type Settings } from '../api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { logout } from '../router';
 
 const route = useRoute();
 
 /** 仪表盘统计数据 */
 const dashboard = ref<DashboardData | null>(null);
+const quarantineOn429 = ref(true);
+const warmupEnabled = ref(false);
+const warmupBaseUtcHour = ref(23);
+const warmupJitterMinutes = ref(30);
+const warmupMaxRetries = ref(2);
+const warmupRetryBackoffSecs = ref(300);
+const warmupAccountGapSecs = ref(45);
+const warmupPollIntervalSecs = ref(60);
+const settingsLoading = ref(false);
 
 /** 加载仪表盘数据 */
 async function loadDashboard() {
@@ -20,12 +30,83 @@ async function loadDashboard() {
   }
 }
 
+async function loadSettings() {
+  try {
+    const settings = await api.getSettings();
+    applySettings(settings);
+  } catch {
+    // 忽略瞬态错误
+  }
+}
+
+function applySettings(settings: Settings) {
+  quarantineOn429.value = settings.quarantine_on_429;
+  warmupEnabled.value = settings.warmup_enabled;
+  warmupBaseUtcHour.value = settings.warmup_base_utc_hour;
+  warmupJitterMinutes.value = settings.warmup_jitter_minutes;
+  warmupMaxRetries.value = settings.warmup_max_retries;
+  warmupRetryBackoffSecs.value = settings.warmup_retry_backoff_secs;
+  warmupAccountGapSecs.value = settings.warmup_account_gap_secs;
+  warmupPollIntervalSecs.value = settings.warmup_poll_interval_secs;
+}
+
+async function toggleQuarantine() {
+  settingsLoading.value = true;
+  try {
+    applySettings(await api.updateSettings({
+      quarantine_on_429: !quarantineOn429.value,
+    }));
+  } catch {
+    // 忽略瞬态错误
+  } finally {
+    settingsLoading.value = false;
+  }
+}
+
+async function toggleWarmup() {
+  settingsLoading.value = true;
+  try {
+    applySettings(await api.updateSettings({
+      warmup_enabled: !warmupEnabled.value,
+    }));
+  } catch {
+    // 忽略瞬态错误
+  } finally {
+    settingsLoading.value = false;
+  }
+}
+
+async function saveWarmupSettings() {
+  settingsLoading.value = true;
+  try {
+    applySettings(await api.updateSettings({
+      warmup_base_utc_hour: warmupBaseUtcHour.value,
+      warmup_jitter_minutes: warmupJitterMinutes.value,
+      warmup_max_retries: warmupMaxRetries.value,
+      warmup_retry_backoff_secs: warmupRetryBackoffSecs.value,
+      warmup_account_gap_secs: warmupAccountGapSecs.value,
+      warmup_poll_interval_secs: warmupPollIntervalSecs.value,
+    }));
+  } catch {
+    // 忽略瞬态错误
+  } finally {
+    settingsLoading.value = false;
+  }
+}
+
 /** 格式化大数字为千分位 */
 function formatNum(n: number): string {
   return n.toLocaleString();
 }
 
-onMounted(loadDashboard);
+function formatUtcHour(hour: number): string {
+  return `UTC ${String(hour).padStart(2, '0')}:00`;
+}
+
+onMounted(() => {
+  loadDashboard();
+  loadSettings();
+});
 </script>
 
 <template>
@@ -59,14 +140,48 @@ onMounted(loadDashboard);
             </router-link>
           </nav>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          @click="logout"
-          class="text-[#8c8475] hover:text-[#29261e] hover:bg-[#f0ebe4]"
-        >
-          退出
-        </Button>
+        <div class="flex items-center gap-3">
+          <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[#f0ebe4]">
+            <span class="text-xs text-[#8c8475]">429 暂停账号</span>
+            <button
+              :disabled="settingsLoading"
+              @click="toggleQuarantine"
+              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none disabled:opacity-50"
+              :class="quarantineOn429 ? 'bg-[#c4704f]' : 'bg-[#d6d0c8]'"
+              :aria-checked="quarantineOn429"
+              role="switch"
+            >
+              <span
+                class="pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200"
+                :class="quarantineOn429 ? 'translate-x-4' : 'translate-x-0'"
+              />
+            </button>
+          </div>
+          <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-[#f6efe6]">
+            <span class="text-xs text-[#8c8475]">预热调度</span>
+            <button
+              :disabled="settingsLoading"
+              @click="toggleWarmup"
+              class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none disabled:opacity-50"
+              :class="warmupEnabled ? 'bg-[#c4704f]' : 'bg-[#d6d0c8]'"
+              :aria-checked="warmupEnabled"
+              role="switch"
+            >
+              <span
+                class="pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200"
+                :class="warmupEnabled ? 'translate-x-4' : 'translate-x-0'"
+              />
+            </button>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            @click="logout"
+            class="text-[#8c8475] hover:text-[#29261e] hover:bg-[#f0ebe4]"
+          >
+            退出
+          </Button>
+        </div>
       </div>
     </header>
 
@@ -104,6 +219,98 @@ onMounted(loadDashboard);
           </CardContent>
         </Card>
       </div>
+
+      <Card class="bg-[linear-gradient(135deg,#fbf5ed_0%,#fffaf5_100%)] border-[#e8e2d9] rounded-2xl !py-0 !gap-0">
+        <CardContent class="py-5 px-5 space-y-4">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <p class="text-sm font-semibold text-[#29261e]">预热计划</p>
+              <p class="text-xs text-[#8c8475] mt-1">
+                围绕 {{ formatUtcHour(warmupBaseUtcHour) }} 在 ±{{ warmupJitterMinutes }} 分钟内随机触发，每天时间不同。
+              </p>
+            </div>
+            <Badge
+              class="border text-xs font-medium"
+              :class="warmupEnabled ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-gray-100 text-gray-500 border-gray-200'"
+            >
+              {{ warmupEnabled ? '已启用' : '已关闭' }}
+            </Badge>
+          </div>
+
+          <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">基准时刻</label>
+              <input
+                v-model.number="warmupBaseUtcHour"
+                type="number"
+                min="0"
+                max="23"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">随机分钟</label>
+              <input
+                v-model.number="warmupJitterMinutes"
+                type="number"
+                min="0"
+                max="720"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">最大重试</label>
+              <input
+                v-model.number="warmupMaxRetries"
+                type="number"
+                min="0"
+                max="10"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">重试秒数</label>
+              <input
+                v-model.number="warmupRetryBackoffSecs"
+                type="number"
+                min="30"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">账号间隔</label>
+              <input
+                v-model.number="warmupAccountGapSecs"
+                type="number"
+                min="1"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+            <div class="space-y-1">
+              <label class="text-[10px] text-[#b5b0a6] uppercase tracking-wider">轮询间隔</label>
+              <input
+                v-model.number="warmupPollIntervalSecs"
+                type="number"
+                min="15"
+                class="w-full h-10 rounded-xl border border-[#e8e2d9] bg-white px-3 text-sm text-[#29261e] focus:outline-none focus:border-[#c4704f]"
+              />
+            </div>
+          </div>
+
+          <div class="flex items-center justify-between gap-3">
+            <p class="text-xs text-[#8c8475]">
+              账号页里单独开启的账号才会参与预热，消息内容会随机短寒暄，不固定为 `hi`。
+            </p>
+            <Button
+              :disabled="settingsLoading"
+              @click="saveWarmupSettings"
+              class="bg-[#c4704f] hover:bg-[#b5623f] text-white rounded-xl"
+            >
+              {{ settingsLoading ? '保存中...' : '保存预热设置' }}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
       <!-- 子路由内容 -->
       <router-view @refresh="loadDashboard" />


### PR DESCRIPTION
## Summary
- add a configurable daily warmup scheduler for accounts with randomized UTC windowing and retry controls
- persist warmup state and global settings in the database and expose admin settings/account controls in the API
- add dashboard and account management UI for warmup configuration and status visibility

## Verification
- cargo build --release
- npm run build
- cargo test --release --test db_migration_test --test account_store_timestamp_test --test account_scheduler_test --test gateway_429_retry_test -- --test-threads=1