### PR TITLE
fix(limit): allow Rejected status to expire by reset_at

### DIFF
--- a/src/service/limit.rs
+++ b/src/service/limit.rs
@@ -765,10 +765,18 @@ fn bottleneck_limit_until(state: &LimitState) -> Option<DateTime<Utc>> {
 fn judge_availability(state: &LimitState, model_class: ModelClass) -> Availability {
     // ---- 账号级门（对两模型一致）----
     if state.status == Some(UnifiedStatus::Rejected) {
-        return Availability::Unavailable {
-            reason: "上游已拒绝（status=rejected）".into(),
-            until: state.reset_at,
-        };
+        // 仅当 reset_at 仍在未来时才视为有效拒绝（与下面 5h / 7d gate 对齐）。
+        // reset_at 过期或缺失则当作 stale 标记，落到后续 gate 判断：否则一旦被
+        // 上游标过 Rejected，selector 会持续过滤该账号 → 没有流量进入
+        // absorb_headers → state.status 永远没机会被新响应覆写，形成死锁。
+        if let Some(reset_at) = state.reset_at {
+            if reset_at > Utc::now() {
+                return Availability::Unavailable {
+                    reason: "上游已拒绝（status=rejected）".into(),
+                    until: Some(reset_at),
+                };
+            }
+        }
     }
     if let Some(until) = state.rate_limited_until {
         if until > Utc::now() {
@@ -1123,12 +1131,42 @@ mod tests {
     }
 
     #[test]
-    fn availability_rejected_is_unavailable() {
+    fn availability_rejected_with_future_reset_is_unavailable() {
+        // status=Rejected + reset_at 在未来 → Unavailable
         let state = LimitState {
             status: Some(UnifiedStatus::Rejected),
+            reset_at: Some(Utc::now() + chrono::Duration::hours(1)),
             ..Default::default()
         };
-        assert!(!judge_availability(&state, ModelClass::Opus).is_available());
+        match judge_availability(&state, ModelClass::Opus) {
+            Availability::Unavailable { until, .. } => assert!(until.is_some()),
+            Availability::Available => panic!("应 Unavailable"),
+        }
+    }
+
+    #[test]
+    fn availability_rejected_with_past_reset_is_available() {
+        // status=Rejected 但 reset_at 已经过去 → 视为 stale，应当 Available。
+        // 回归用例：huiguan-yewu 2026-05-18 死锁场景 —— 5h 窗口在 reset 之后
+        // selector 仍然把账号当作 Rejected 过滤，因没有流量来覆写 status。
+        let state = LimitState {
+            status: Some(UnifiedStatus::Rejected),
+            reset_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            ..Default::default()
+        };
+        assert!(judge_availability(&state, ModelClass::Opus).is_available());
+    }
+
+    #[test]
+    fn availability_rejected_without_reset_is_available() {
+        // status=Rejected 但 reset_at 缺失（上游未带 reset 头）→ 仍按 stale 处理，
+        // 避免在缺信息时永久封禁该账号。
+        let state = LimitState {
+            status: Some(UnifiedStatus::Rejected),
+            reset_at: None,
+            ..Default::default()
+        };
+        assert!(judge_availability(&state, ModelClass::Opus).is_available());
     }
 
     #[test]
@@ -1871,10 +1909,13 @@ mod tests {
     }
 
     /// 账号级 status=Rejected（rep_claim=five_hour 或 seven_day）→ 两模型都封。
+    /// 注：需要带未来 reset_at；缺失 reset_at 时 Rejected 视为 stale（见
+    /// `availability_rejected_without_reset_is_available`）。
     #[test]
     fn account_level_status_rejected_blocks_both_models() {
         let state = LimitState {
             status: Some(UnifiedStatus::Rejected),
+            reset_at: Some(Utc::now() + chrono::Duration::hours(1)),
             ..Default::default()
         };
         assert!(!judge_availability(&state, ModelClass::Opus).is_available());


### PR DESCRIPTION
# fix(limit): allow Rejected status to expire by `reset_at`

## Summary

`judge_availability` 在 `state.status == UnifiedStatus::Rejected` 时无条件返回 `Unavailable`，**没有时间界**——和相邻的 `five_hour` / `seven_day` / `rate_limited_until` 三个 gate 形成不一致（那三个都用 `> Utc::now()` 自动过期）。一旦账号被上游标过 Rejected，selector 在 `select` 阶段就把它过滤掉，没有真实流量进入 `absorb_headers` → `state.status` 永远没机会被新响应覆写 → 形成死锁，唯一自愈是进程重启。

## Repro

故障形态：

1. 账号撞到 5h 窗口上限，Anthropic 返回 429 + `anthropic-ratelimit-unified-status: rejected` + `anthropic-ratelimit-unified-reset` 指向若干小时后；`absorb_headers` 把 `state.status = Rejected` 写进 LimitState
2. `unified-reset` 时刻过去之后，`/api/oauth/usage` 报 `five_hour util=0%`（窗口已 reset），账号实际上是健康的
3. 但 `judge_availability` 仍然返回 `Unavailable`，因为 status=Rejected 没有时间界检查
4. selector 把该账号过滤掉 → 没有真实请求落到上游 → 不触发 `absorb_headers` → 无法覆写 `state.status`
5. 多账号部署里一旦每个活跃账号都落到这个 stale-Rejected 状态，gateway 持续打：

    ```
    select: N of N schedulable accounts filtered by limit state: [...]
    ```

   网关返回上游不可用，必须 `docker restart` 才能通过 `clear_all_stale_rate_limits` (src/store/account_store.rs:444-460) 清掉 DB 列、内存 map 从空开始。

## Root cause

```rust
// src/service/limit.rs::judge_availability (修复前)
if state.status == Some(UnifiedStatus::Rejected) {
    return Availability::Unavailable {
        reason: "上游已拒绝（status=rejected）".into(),
        until: state.reset_at,   // 只用于 UI 展示，没有任何 gating 作用
    };
}
```

链路：

| 阶段 | 模块 | 行为 |
|---|---|---|
| 进 | `absorb_headers` → `compute_new_state` → `apply_parsed` | 把响应头 `anthropic-ratelimit-unified-status: rejected` 写到 `state.status` |
| 卡 | `judge_availability` | reset 时刻过后仍然返回 `Unavailable` |
| 滤 | `select` (src/service/account.rs:172-190) | 用 `availability().is_available()` 把账号从候选剔除 |
| 断 | 该账号无流量 | `absorb_headers` 不再被调用 → 没有新响应来覆写 `state.status` |

`state.rate_limited_until` 在同函数下面已经做过 `until > Utc::now()` 检查（L774），过期自动放行；`state.five_hour.resets_at` 和 `state.seven_day.resets_at` 也都有 `> Utc::now()` 检查（L790、L798）；只有 `state.status == Rejected` 这条 gate 是"永久"标记，不对齐。

## Fix

对齐 5h / 7d gate 的形态——只有 `reset_at` 仍在未来时才视为有效拒绝；过期或缺失就当 stale 跳过，让后续 gate（5h util、7d util、`rate_limited_until` 等）继续判定：

```rust
if state.status == Some(UnifiedStatus::Rejected) {
    if let Some(reset_at) = state.reset_at {
        if reset_at > Utc::now() {
            return Availability::Unavailable {
                reason: "上游已拒绝（status=rejected）".into(),
                until: Some(reset_at),
            };
        }
    }
}
```

不改 `compute_new_state` / `apply_parsed` / `ingest_usage_json` / selector——blast radius 控制在 `judge_availability` 内部，10 行生产代码改动。

## Tests

`cargo test --lib` 全部 **133/133** 通过。

新增：
- `availability_rejected_with_future_reset_is_unavailable`：保留未来 reset 的拦截语义
- `availability_rejected_with_past_reset_is_available`：死锁形态的回归用例
- `availability_rejected_without_reset_is_available`：覆盖上游未带 reset 头的情况

调整：
- 旧 `availability_rejected_is_unavailable` 删除（隐含编码了 buggy 契约）
- 旧 `account_level_status_rejected_blocks_both_models` 加 `reset_at = now+1h` 以保留"账号级 gate 覆盖两模型"的测试意图

## Verification

修复镜像本地构建后通过 `docker save | docker load` 推到生产环境的两个 cc-bridge 实例（一个双账号 group、一个单账号），灰度替换 `:latest` tag。两个实例启动干净：

- `cleared stale rate-limit fields on N account(s)`
- `claude-code-gateway listening on http://0.0.0.0:5674`
- 无 panic / stack trace
- 单账号实例正常 absorb 上游 200 响应（`limit absorb: ... status=200 → flush (first-fill)`）
- 未再观察到 `select: N of N schedulable accounts filtered by limit state` 持续超过 reset 时间的现象

`docker-compose.yml.bak.fix-rejected` 备份保留，一行 `cp + docker compose up -d` 可回到 `:latest`。

## Compatibility

- 行为变化：以前 `status=Rejected` 且 `reset_at=None` → 永久 Unavailable；现在变成 Available（落到后续 gate 继续判）
- 只影响 selector 的可调度判定，**不影响 `absorb_headers` 的写入路径**——上游若仍在 reject，下一次请求会立刻把账号重新标 Rejected，所以"误放过"窗口最长 = 一次请求 RTT
- DB schema、storage、API、UI 全部不变
